### PR TITLE
Fix xenserver-install-wizard makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,16 @@ install:
 	install -m 0644 \
 		grub.py \
 		hostname.py \
+		interfaces.py \
 		iptables.py \
 		logging.py \
-		networking.py 
+		network.py \
+		networkscripts.py \
 		openstack.py \
 		replace.py \
-		storage.py 
+		storage.py \
 		templates.py \
+		toolstack.py \
 		tui.py \
 		xapi.py \
 		$(DESTDIR)/$(DIR)


### PR DESCRIPTION
interfaces.py, networkscripts.py, storage.py and toolstack.py were not being installed in the package, and networking.py had been renamed to network.py
