### PR TITLE
wizard: Only update GRUB2 if its configuration has been changed

### DIFF
--- a/xenserver-install-wizard.py
+++ b/xenserver-install-wizard.py
@@ -47,8 +47,8 @@ if __name__ == "__main__":
 	if r:
 		need_to_reboot = True
 		replace.file(r[0], r[1])
-        if os.path.isfile("/etc/default/grub"):
-                subprocess.call(["update-grub"])
+		if os.path.isfile("/etc/default/grub"):
+			subprocess.call(["update-grub"])
 	r = network.analyse()
 	if r:
 		need_to_reboot = True


### PR DESCRIPTION
The diff looks odd because the old lines were indented with spaces and the new ones are indented with tabs to match the rest of the file.   This change does move the update-grub call under the 'if r:' clause, so it is only called if the configuration file is updated.
