### PR TITLE
openstack: Store images in /var/lib/xapi instead of /var/run

### DIFF
--- a/openstack.py
+++ b/openstack.py
@@ -31,7 +31,7 @@ def analyse():
 		if len(hosts) <> 1:
 			print >>sys.stderr, "ERROR: host is already in a pool"
 			return
-		path = "/var/run/sr-mount/%s" % uuid
+		path = "/var/lib/xapi/sr-mount/%s" % uuid
 		mkdir(path)
 		sr = x.xenapi.SR.introduce(uuid, path, "Files stored in %s" % path, "ext", "default", False, {})
 		pbd = x.xenapi.PBD.create({ "host": hosts[0], "SR": sr, "device_config": {"path": path}})


### PR DESCRIPTION
/var/run is a tmpfs on Ubuntu, so if images can be created at all
(the tmpfs is small) they would be lost on reboot.

/var/lib/xapi is created by the xapi package, so it's safe to assume
it will be present.

Signed-off-by: Euan Harris euan.harris@citrix.com
