### PR TITLE
Updated automatic install:

### DIFF
--- a/tui.py
+++ b/tui.py
@@ -13,7 +13,7 @@ class Tui():
 		self.auto_default = auto_default
 
 	def yesno(self, question, default=None):
-		if self.auto_default and default:
+		if self.auto_default and default is not None:
 			return default
 		width = len(question)
 		if width > 80:
@@ -25,7 +25,7 @@ class Tui():
 		return False
 
 	def choose(self, question, options, default=None):
-		if self.auto_default and default:
+		if self.auto_default and default is not None:
 			return default
 		cmd = [ find_whiptail(), "--menu", question, "10", "50", str(len(options)) ]
 		for option in options:
@@ -36,7 +36,7 @@ class Tui():
 		return str(y[1])
 
 	def text(self, question, default):
-		if self.auto_default and default:
+		if self.auto_default:
 			return default
 		cmd = [ find_whiptail(), "--inputbox", question, "8", "50", default ]
 		x = subprocess.Popen(cmd, stderr = subprocess.PIPE)

--- a/xapi.py
+++ b/xapi.py
@@ -38,8 +38,24 @@ def start():
 	for service in services:
 		if service not in already_started:
 			start_service(service)
-	# Wait for XAPI to start
-	time.sleep(5)
+
+	# Wait for XAPI to start - up to 30 seconds (5*6)
+	attempts = 6
+	login_works = False
+	while (attempts > 0):
+		try:
+			try:
+				x = xapi.open()	
+				x.login_with_password("root", "")
+				login_works = True
+				break
+			finally:
+				x.logout()
+		except:
+			time.sleep(5)
+			attempts = attempts - 1
+	if login_works == False:
+		raise Exception("Could not log in to XAPI")
 
 def open():
 	return XenAPI.xapi_local()


### PR DESCRIPTION
- Reboot prompt was still displayed due to faulty handling of default
- Better logic to wait for XAPI to be running.

NOTE: I have not been able to test this, I believe due to an existing bug
where XAPI is never ready because it's not running under Xen.
This patch may be irrelevant depending on the fix identified for running XAPI
and how the xe commands will be run, but I was asked to share it anyway
