### PR TITLE
xapi now needs squeezed to be running to determine domain 0 memory

### DIFF
--- a/xapi.py
+++ b/xapi.py
@@ -26,6 +26,7 @@ services = [
 	"forkexecd",
 	"xcp-networkd",
 	"ffs",
+	"squeezed",
 	"xapi",
 ]
 


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
