### PR TITLE
grub: there's no need to cap dom0 memory since we can balloon dom0

### DIFF
--- a/grub.py
+++ b/grub.py
@@ -47,7 +47,7 @@ def make_xen_based_on((name, args,)):
 	kernelpath = "/boot/xen.gz"
 	if os.path.ismount("/boot"):
 		kernelpath = "/xen.gz"
-	kernel = "kernel %s dom0_mem=2048M,max:2048M loglvl=all guest_loglvl=all" % kernelpath
+	kernel = "kernel %s loglvl=all guest_loglvl=all" % kernelpath
 	for a in args:
 		a = a.strip()
 		if a.startswith("kernel "):


### PR DESCRIPTION
NB: this means we're defaulting to a 'developer friendly' environment
rather than a 'production' environment. Developers like to have
lots of memory available for compilers, while in production it's
better to dedicate it to running VMs.

Signed-off-by: David Scott dave.scott@eu.citrix.com
