### PR TITLE
get_kernel should return an empty string

### DIFF
--- a/grub.py
+++ b/grub.py
@@ -23,12 +23,18 @@ def list_kernels(lines):
 	return result
 
 def get_kernel((name, args,)):
+	"""
+
+	>>> get_kernel(('a', []))
+	''
+	"""
 	for arg in args:
 		arg = arg.strip()
 		if arg.startswith("kernel"):
 			bits = arg.split()
 			kernel = bits[1]
 			return kernel
+	return ''
 
 def get_default(lines):
 	for line in lines:


### PR DESCRIPTION
fixes issue #47

If your bootloader has extra entries, which don't have a kernel
parameter, the get_kernel function returned None, and thus the is_xen
evaluation failed, as it were expecting a string.
