### PR TITLE
Must use UUIDs rather than /dev/xvda1 when regenerating grub

### DIFF
--- a/grub2.py
+++ b/grub2.py
@@ -108,6 +108,8 @@ def analyse(tui, etc_default_grub = GRUB_CONF, grub_cfg_glob = GRUB_CFG_GLOB):
 			tmp = line.strip()
 			if tmp.startswith("GRUB_DEFAULT="):
 				new_lines.append("GRUB_DEFAULT='%s'" % xen_entry)
+			elif tmp.startswith("GRUB_DISABLE_LINUX_UUID="):
+				new_lines.append("GRUB_DISABLE_LINUX_UUID='false'")
 			else:
 				new_lines.append(line[0:-1])
 


### PR DESCRIPTION
When rebooting under xen the device won't be the same as the original device
if we're running in the cloud, as the original device will be xvda1 (or similar)
but the new device will be sda1
