### PR TITLE
xapi startup blocks until xcp-rrdd is available

### DIFF
--- a/xapi.py
+++ b/xapi.py
@@ -25,6 +25,7 @@ services = [
 	"message-switch",
 	"forkexecd",
 	"xcp-networkd",
+	"xcp-rrdd",
 	"ffs",
 	"squeezed",
 	"xapi",


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@citrix.com
