### PR TITLE
Stop XAPI running if we're not in dom0.

### DIFF
--- a/hostname.py
+++ b/hostname.py
@@ -9,7 +9,7 @@ def hostname():
 	return str(y[0]).strip()
 
 def analyse(tui):
-	x = xapi.open()
+	x = xapi.connect()
 	x.login_with_password("root", "")
 	try:
 		hosts = x.xenapi.host.get_all()

--- a/network.py
+++ b/network.py
@@ -8,7 +8,7 @@ import xapi, interfaces, networkscripts
 
 def list_devices(tui):
 	"""Use xapi to query the PIFs on the local host"""
-	x = xapi.open()	
+	x = xapi.connect()
 	x.login_with_password("root", "")
 	no_configuration = {
 		"devices": [], # none will be managed by xapi
@@ -58,7 +58,7 @@ def choose_management(tui, config):
 
 def configure(config, new_interfaces):
 	"""Configure [new_interfaces] through the XenAPI"""
-        x = xapi.open() 
+        x = xapi.connect()
         x.login_with_password("root", "")
         try:
 		for device in new_interfaces:

--- a/networkscripts.py
+++ b/networkscripts.py
@@ -37,7 +37,7 @@ def save_sysconfig(x):
 def analyse(tui, config):
 	devices = config["devices"]
 
-	x = xapi.open()	
+	x = xapi.connect()
 	x.login_with_password("root", "")
 	try:
 		file_changes = []

--- a/openstack.py
+++ b/openstack.py
@@ -17,7 +17,7 @@ def generate_uuid():
         return str(y[0].strip())
 
 def analyse(tui):
-	x = xapi.open()
+	x = xapi.connect()
 	x.login_with_password("root", "")
 	try:
 		srs = x.xenapi.SR.get_all_records()

--- a/storage.py
+++ b/storage.py
@@ -9,7 +9,7 @@ def mkdir(path):
 		print >>sys.stderr, "ERROR: failed to mkdir -p %s" % path
 
 def analyse(tui):
-	x = xapi.open()
+	x = xapi.connect()
 	x.login_with_password("root", "")
 	try:
 		pool = x.xenapi.pool.get_all()[0]

--- a/xenserver-install-wizard.py
+++ b/xenserver-install-wizard.py
@@ -47,8 +47,6 @@ if __name__ == "__main__":
 		replace.file(r[0], r[1])
 		logging.restart()
 	need_to_reboot = stop_xend (tui)
-	xapi.start ()
-	need_to_reboot = False
         if os.path.isfile("/etc/default/grub"):
                 r = grub2.analyse(tui)
         elif os.path.isfile("/boot/grub/grub.conf"):
@@ -61,6 +59,11 @@ if __name__ == "__main__":
 		replace.file(r[0], r[1])
 		if os.path.isfile("/etc/default/grub"):
 			subprocess.call(["update-grub"])
+
+	xapi.start ()
+        # If XAPI started then we don't need to reboot for any grub changes
+	need_to_reboot = False
+
 	r = network.analyse(tui)
 	if r:
 		need_to_reboot = True


### PR DESCRIPTION
Fixes issue 438 (original issue) by preventing XAPI from running
if we're not in dom0, i.e. we're in a nested Xen environment and
we have not yet rebooted.
