### PR TITLE
Block xapi waiting for xenopsd-xc

### DIFF
--- a/xapi.py
+++ b/xapi.py
@@ -27,6 +27,7 @@ services = [
 	"forkexecd",
 	"xcp-networkd",
 	"xcp-rrdd",
+        "xenopsd-xc",
 	"ffs",
 	"squeezed",
 	"xapi",


### PR DESCRIPTION
Second fix for issue 438
